### PR TITLE
Traduzione sezione "Tecniche avanzate"

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -88,7 +88,7 @@
                 <li><a href="/mostri-non-morti">Legioni dei Non Morti</a></li>
                 <li><a href="/mostri-orde">Orde Fameliche</a></li>
                 <li><a href="/mostri-piani">Poteri Planari</a></li>
-                <li><a href="/mostri-profondita">Profondità della Terra <span class="label label-default">Inglese</span></a></li>
+                <li><a href="/mostri-profondita">Profondità della Terra</a></li>
               </ul>
             </li>
 			<!-- li class="dropdown">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -71,7 +71,7 @@
                 <li><a href="/prima-sessione">Prima Sessione</a></li>
                 <li><a href="/fronti">Fronti</a></li>
                 <li><a href="/il-mondo">Il Mondo</li>
-                <li><a href="/tecniche-avanzate">Tecniche Avanzate <span class="label label-default">inglese</span></a></li>
+                <li><a href="/tecniche-avanzate">Tecniche Avanzate</a></li>
               </ul>
             </li>
             

--- a/index.md
+++ b/index.md
@@ -26,12 +26,6 @@ Considero questo sito una risorsa pubblica, e il testo completo è disponibile s
 
 # Indice Generale
 
-La traduzione è **quasi completa**, manca solo un capitolo relativo alle ambientazioni mostruose (Profondità della Terra).
-
-Oltre alle schede delle classi, sono disponibili le schede delle **[mosse base](pdf/mosse.pdf)** e del **[riassunto del gm](pdf/gm.pdf)**, adesso aggiornate alla nostra traduzione!
-
-Sono stati tradotti i seguenti capitoli:
-
 <ul>
 	<li>Parte I,<b> Il Gioco</b></li>
 	<ul>
@@ -60,6 +54,7 @@ Sono stati tradotti i seguenti capitoli:
 		<li><a href="prima-sessione">Prima Sessione</a></li>
         <li><a href="fronti">Fronti</a></li>
         <li><a href="il-mondo">Il Mondo</a></li>
+        <li><a href="tecniche-avanzate">Tecniche Avanzate</a></li>
 	</ul>
     <li>Parte IV, <b>I Mostri</b></li>
 	<ul>
@@ -75,6 +70,8 @@ Sono stati tradotti i seguenti capitoli:
 		<li><a href="mostri-profondita">Profondità della Terra</a></li>
 	</ul>
 </ul>
+
+Oltre alle schede delle classi, sono disponibili le schede delle **[mosse base](pdf/mosse.pdf)** e del **[riassunto del gm](pdf/gm.pdf)**, adesso aggiornate alla nostra traduzione!
 
 **Nota**: alcuni segni di punteggiatura sono ancora da uniformare, come le virgolette. A lavoro finito verranno sistemati in un controllo tipografico generale.
 

--- a/index.md
+++ b/index.md
@@ -71,7 +71,8 @@ Sono stati tradotti i seguenti capitoli:
 		<li><a href="mostri-genti">Genti del Reame</a></li>
 		<li><a href="mostri-non-morti">Legioni dei Non Morti</a></li>
 		<li><a href="mostri-orde">Orde Fameliche</a></li>
-		<li><a href="mostri-piani">Esperimenti Perversi</a></li>
+		<li><a href="mostri-piani">Poteri Planari</a></li>
+		<li><a href="mostri-profondita">Profondità della Terra</a></li>
 	</ul>
 </ul>
 

--- a/mostri-profondita.md
+++ b/mostri-profondita.md
@@ -2,4 +2,196 @@
 title: Profondità della Terra
 layout: default
 ---
-Capitolo non tradotto, consultare la [versione inglese](https://book.dwgazetteer.com/monsters_depths.html).
+
+## Aboleth 
+
+***Gruppo, Enorme, Intelligente***
+
+Tentacolo (d10+3 danni) 18 PF 0 Armatura
+
+*Lungo*
+
+**Qualità Speciali**: Telepatia
+
+Nelle profondità sotto la superficie del mondo, in mari d'acqua dolce inviolati dal sole, abitano gli aboleth. Pesci grandi come balene, con strane escrescenze come tentacoli gelatinosi che usano per sondare le rive senza luce. Sono serviti da schiavi: cieche vittime albine, di qualsiasi razza abbastanza sfortunata da imbattersi in loro, svuotate di pensiero e vita dal potere della mente aliena degli aboleth. Nelle profondità complottano l'uno contro l'altro, cultisti pisciformi che costruiscono e scavano verso la superficie fino a quando, un giorno, la sfonderanno. Per ora, dormono e sognano e guidano i loro pallidi servitori a eseguire i loro ordini. *Istinto*: Comandare
+
+- Invadere una mente
+- Rivolgere i servitori contro di loro
+- Mettere in atto un piano
+
+## Drago dell'apocalisse
+
+***Solitario, Enorme, Magico, Divino***
+
+Morso (b\[2d12\]+9 danni, 4 perforanti) 26 PF 5 Armatura
+
+*Lungo, Possente, Devastante*
+
+**Qualità Speciali**: Pelle metallica spessa un pollice, Conoscenza sovrannaturale, Ali
+
+La fine di ogni cosa avverrà in un rogo di alberi, terra e dell'aria stessa. Arriverà su pianure e montagne non da fuori, ma da dentro questo mondo. Nato dal grembo della terra più profonda arriverà il Drago che Finirà il Mondo. Al suo passaggio tutto diventerà cenere e rabbia e il Dungeon World, morente, andrà alla deriva nello spazio planare privo di vita. Dicono che adorare il Drago dell'Apocalisse sia un invito alla follia. Dicono che amarlo sia conoscere l'oblio. Il risveglio sta arrivando. *Istinto*: Porre fine al mondo
+
+- Mettere in moto un disastro
+- Soffiare gli elementi
+- Agire con perfetta preveggenza
+
+## Progenie del caos
+
+***Solitario, Amorfo***
+
+Tocco del Caos (d10 danni) 19 PF 1 Armatura
+
+*Medio, Lungo*
+
+**Qualità Speciali**: Forma caotica
+
+Scacciato dalla città, un cultista trova rifugio in borghi e villaggi. Scovato anche lì, fugge verso le colline e incide la sua devozione sulle pareti delle caverne. Trovato di nuovo, viene cacciato con coltelli e torce nelle profondità, strisciando sempre più in basso fino a quando, nei luoghi più profondi, si scopre perduto. Dapprima dimentica il suo nome. Poi dimentica la sua forma. I suoi dei del caos, i più amati, lo benedicono donandogliene una nuova. *Istinto*: Minare l'ordine costituito
+
+- Riscrivere la realtà
+- Liberare il caos dalla sua prigione
+
+## Chuul
+
+***Gruppo, Grande, Cauto***
+
+Artigli (d8+1 danni, 3 perforanti) 10 PF 4 Armatura
+
+*Medio, Lungo, Devastante*
+
+**Qualità Speciali**: Anfibio
+
+Il tuo peggior incubo da impepata di cozze che prende vita. Una sorta di mezzo-uomo, mezzo-gambero, maledetto da un'intelligenza primordiale e benedetto da un paio di chele affilate come rasoi. Cose strane si nascondono nelle pozze maleodoranti, in caverne che era meglio rimanessero inesplorate, e il chuul è una di queste. Se ne avvisti uno, il meglio a cui puoi ambire è una mazza pesante per frantumargli il guscio e magari un po' di burro all'aglio. Mmmm. *Istinto*: Fare a fette
+
+- Tagliare qualcosa in due con le possenti chele
+- Ritirarsi in acqua
+
+## Elfo delle profondità, assassino
+
+***Gruppo, Intelligente, Organizzato***
+
+Lama avvelenata (d8 danni, 1 perforante) 6 PF 1 Armatura
+
+*Medio*
+
+Non si trattò di una bazzecola come una guerra santa o di territorio. Nessun disaccordo tra regine portò alla grande scissione degli elfi. Fu la tristezza. Fu il greve declino del creato per mano delle razze inferiori. La gloria di tutto ciò che gli elfi avevano costruito si andava incrinando e trasformando in vetro. Alcuni quindi, scelsero di isolarsi dal mondo; affranti, in lacrime, voltarono le spalle agli uomini e ai nani. Altri però, furono sopraffatti da qualcosa di nuovo. Un sentimento che nessun elfo aveva mai provato prima. Disprezzo. L'odio riempì quegli elfi, li distorse ed essi si rivolsero contro i loro cugini più deboli. Alcuni dimorano ancora nelle profondità dopo il grande esodo. Altri si nascondono tra noi con lame intrise di veleno di ragno, infliggendo la più bizzarra delle punizioni: la vendetta elfica. *Istinto*: Disprezzare le razze della superficie
+
+- Avvelenare
+- Liberare un antico incantesimo
+- Chiamare rinforzi
+
+## Elfo delle profondità, maestro di spada
+
+***Gruppo, Intelligente, Organizzato***
+
+Lama spinata (b\[2d8\]+2 danni, 1 perforante) 6 PF 2 Armatura
+
+*Medio*
+
+Ormai da secoli gli elfi delle profondità hanno perso la dolcezza e la serafica tranquillità dei loro luminosi cugini, ma non ne hanno abbandonato la grazia. Si muovono con una rapidità e una bellezza da far venire le lacrime agli occhi a qualsiasi guerriero. Nell'oscurità si sono perfezionati. La crudeltà ha infettato la loro scherma, la malvagità ha preso il sopravvento. Lame spinose e flagelli hanno sostituito le splendenti lance da stendardo portate in battaglia dagli elfi in superficie. I maestri di spada, nei clan degli elfi delle profondità, non cercano solo di uccidere ma di punire con ogni colpo delle loro lame. La malvagità e il dolore sono la loro moneta. *Istinto*: Punire gli infedeli
+
+- Infliggere dolore fuori misura
+- Usare il buio a proprio vantaggio
+
+## Elfo delle profondità, sacerdote
+
+***Solitario, Divino, Intelligente, Organizzato***
+
+Punizione (d10+2 danni) 14 PF 0 Armatura
+
+*Medio, Lungo*
+
+**Qualità Speciali**: Connessione divina
+
+Gli spiriti degli alberi e la Signora della Luce Solare sono molto, molto lontani dagli abissi dove dimorano gli elfi delle profondità. Lì costoro scoprirono che nuovi dei attendevano che i loro figli tornassero a casa. Dèi dei ragni, delle foreste fungine e delle cose che sussurrano nelle caverne proibite. Gli elfi delle profondità, sempre in sintonia con il mondo intorno a loro, ascoltarono con intento maligno i loro nuovi dèi e vi trovarono una nuova fonte di potere. L'odio chiama l'odio e alleanze funeste furono siglate. Anche tra questi quartieri pieni di disprezzo, la pietà trova modo di esprimersi. *Istinto*: Comminare la vendetta divina
+
+- Intessere incantesimi di odio e malizia
+- Radunare gli elfi delle profondità
+- Tramandare conoscenze divine
+
+## Drago
+
+***Solitario, Enorme, Terrificante, Cauto, Accumulatore***
+
+Morso (b\[2d12\]+5 danni, 4 perforanti) 16 PF 5 Armatura
+
+*Lungo, Devastante*
+
+**Qualità Speciali**: Sangue elementale, Ali
+
+Sono le cose più grandi e terribili che questo mondo avrà mai da offrire. *Istinto*: Dominare
+
+- Piegare un elemento alla propria volontà
+- Esigere un tributo
+- Agire con sdegno
+
+## Sventratore grigio
+
+***Solitario, Grande***
+
+Artigli laceranti (d10+3 danni, 3 perforanti) 16 PF 1 Armatura
+
+*Medio, Lungo, Possente*
+
+Già da solo, lo sventratore è una forza di totale distruzione. Enorme e coriaceo, con una fila di denti infrangibili e artigli a complemento, lo sventratore sembra non avere gioia più grande che fare a pezzi le cose. Pietra, carne o acciaio, poco importa. Tuttavia, gli sventratori grigi raramente vanno in giro da soli. Si legano ad altre creature. Alcuni alla nascita, altri quando sono già completamente sviluppati, ma uno sventratore seguirà il padrone a cui si è legato ovunque egli vada, portandogli succulente offerte e proteggendolo mentre dorme. Trovare uno sventratore senza padrone ti farà diventare ricco, se sopravvivi per vendertelo. *Istinto*: Servire
+
+- Fare a pezzi qualcosa
+
+## Magmin
+
+***Orda, Intelligente, Organizzato, Accumulatore***
+
+Martello fiammeggiante (d6+2 danni) 7 PF 4 Armatura
+
+*Medio, Lungo*
+
+**Qualità Speciali**: Sangue infuocato
+
+Simili ai nani e industriosi, i magmin sono tra i più profondi abitanti del Dungeon World. Li si trova in città di ottone e ossidiana costruite vicino al nucleo fuso del pianeta, a vivere una vita dedicata all'artigianato, soprattutto quello basato sul fuoco e gli oggetti magici a esso correlati. Burberi e bizzarri, raramente si degnano di parlare con chi bussa alla loro porta con una richiesta, anche a coloro che sono riusciti, in qualche modo, a sopravvivere al calore infernale. Tuttavia, niente li ingolosisce più di un oggetto finemente lavorato e imparare la forgiatura da un artigiano magmin significa apprendere segreti sconosciuti ai fabbri di superficie. Come tante altre cose, far visita ai magmin è un bilancio tra rischi e benefici. *Istinto*: Creare
+
+- Offrire uno scambio o un affare
+- Colpire con fuoco o magia
+- Fornire l'oggetto giusto, a un prezzo
+
+## Minotauro
+
+***Solitario, Grande***
+
+Ascia (d10+1 danni) 16 PF 1 Armatura
+
+*Medio, Lungo*
+
+**Qualità Speciali**: Senso di direzione infallibile
+
+“Testa di uomo, corpo di toro. No, aspetta, mi sa che era al contrario. È la testa del toro e il corpo dell'uomo. Pure gli zoccoli, no? Giusto? Mi pare che il vecchio re avesse detto qualcosa su un labirinto? Accidenti! Lo sai che non riesco a pensare se mi metti pressione. Cosa è stato? Oh dèi, penso che stia arrivando...” *Istinto*: Intrappolare
+
+- Confondere
+- Disorientare
+
+## Naga
+
+***Solitario, Intelligente, Organizzato, Accumulatore, Magico***
+
+Morso (d10 danni) 12 PF 2 Armatura
+
+*Medio, Lungo*
+
+Tra gli esseri più ambiziosi e territoriali che si conoscano, i naga molto raramente vivono senza un solido e insidioso culto di seguaci. Potrai trovarne spesso i segni nei villaggi di montagna: un sigillo serpentino scarabocchiato su una parete di una taverna o una chiesa del posto bruciata e rasa al suolo. Persone che scompaiono nelle miniere. Uomini e donne che portano il marchio del serpente. Al centro di tutto ciò, c'è sempre un naga: un'antica razza ora caduta nell'oscurità ma ancora fiera, con la testa di un uomo sopra un corpo serpentiforme. Esistono varianti di queste creature, con diverse linee di sangue e ataviche ambizioni, ma tutti sono maestri manipolatori e governano forze magiche da non sottovalutare. *Istinto*: Guidare
+
+- Mandare un seguace alla morte
+- Usare antiche magie
+- Proporre un affare o un patto
+
+## Salamandra
+
+***Orda, Grande, Intelligente, Organizzato, Planare***
+
+Lancia fiammeggiante (b\[2d6\]+3 danni) 7 PF 3 Armatura
+
+*Corto, Medio, Lungo*
+
+**Qualità Speciali**: Scavare
+
+“Gli scavi hanno portato alla luce quello che i rapporti chiamavano un cancello di basalto. Pietra nera incisa con rune fiammeggianti. Quando lo hanno disotterrato, i maghi lo hanno dichiarato inerte, ma ulteriori prove suggeriscono che fosse una valutazione errata. L'intera squadra è scomparsa. Quando siamo arrivati, il cancello brillava. La sua luce riempiva tutta la caverna. Potevamo vedere dall'ingresso che l'area si era riempita di queste creature, simili a uomini dalla pelle rossa e arancione, alti come un orco ma con una coda di serpente al posto delle gambe. Erano vestiti, alcuni avevano persino armature di vetro nero. Comunicavano in una lingua che suonava come grasso sul fuoco. Ho proposto di andarcene, ma il sergente non ha voluto darmi retta. Avete già letto quel che è successo dopo, signore. So che sono l'unico ad essere tornato, ma quello che ho detto è la verità. Il cancello è aperto, ora. Questo è solo l'inizio!” *Istinto*: Consumare tra le fiamme
+
+- Evocare fuoco elementale
+- Sciogliere (letteralmente) le menzogne

--- a/mostri-profondita.md
+++ b/mostri-profondita.md
@@ -19,6 +19,37 @@ Nelle profondità sotto la superficie del mondo, in mari d'acqua dolce inviolati
 - Rivolgere i servitori contro di loro
 - Mettere in atto un piano
 
+## Chuul
+
+***Gruppo, Grande, Cauto***
+
+Artigli (d8+1 danni, 3 perforanti) 10 PF 4 Armatura
+
+*Medio, Lungo, Devastante*
+
+**Qualità Speciali**: Anfibio
+
+Il tuo peggior incubo da impepata di cozze che prende vita. Una sorta di mezzo-uomo, mezzo-gambero, maledetto da un'intelligenza primordiale e benedetto da un paio di chele affilate come rasoi. Cose strane si nascondono nelle pozze maleodoranti, in caverne che era meglio rimanessero inesplorate, e il chuul è una di queste. Se ne avvisti uno, il meglio a cui puoi ambire è una mazza pesante per frantumargli il guscio e magari un po' di burro all'aglio. Mmmm. *Istinto*: Fare a fette
+
+- Tagliare qualcosa in due con le possenti chele
+- Ritirarsi in acqua
+
+## Drago
+
+***Solitario, Enorme, Terrificante, Cauto, Accumulatore***
+
+Morso (b\[2d12\]+5 danni, 4 perforanti) 16 PF 5 Armatura
+
+*Lungo, Devastante*
+
+**Qualità Speciali**: Sangue elementale, Ali
+
+Sono le cose più grandi e terribili che questo mondo avrà mai da offrire. *Istinto*: Dominare
+
+- Piegare un elemento alla propria volontà
+- Esigere un tributo
+- Agire con sdegno
+
 ## Drago dell'apocalisse
 
 ***Solitario, Enorme, Magico, Divino***
@@ -34,36 +65,6 @@ La fine di ogni cosa avverrà in un rogo di alberi, terra e dell'aria stessa. Ar
 - Mettere in moto un disastro
 - Soffiare gli elementi
 - Agire con perfetta preveggenza
-
-## Progenie del caos
-
-***Solitario, Amorfo***
-
-Tocco del Caos (d10 danni) 19 PF 1 Armatura
-
-*Medio, Lungo*
-
-**Qualità Speciali**: Forma caotica
-
-Scacciato dalla città, un cultista trova rifugio in borghi e villaggi. Scovato anche lì, fugge verso le colline e incide la sua devozione sulle pareti delle caverne. Trovato di nuovo, viene cacciato con coltelli e torce nelle profondità, strisciando sempre più in basso fino a quando, nei luoghi più profondi, si scopre perduto. Dapprima dimentica il suo nome. Poi dimentica la sua forma. I suoi dei del caos, i più amati, lo benedicono donandogliene una nuova. *Istinto*: Minare l'ordine costituito
-
-- Riscrivere la realtà
-- Liberare il caos dalla sua prigione
-
-## Chuul
-
-***Gruppo, Grande, Cauto***
-
-Artigli (d8+1 danni, 3 perforanti) 10 PF 4 Armatura
-
-*Medio, Lungo, Devastante*
-
-**Qualità Speciali**: Anfibio
-
-Il tuo peggior incubo da impepata di cozze che prende vita. Una sorta di mezzo-uomo, mezzo-gambero, maledetto da un'intelligenza primordiale e benedetto da un paio di chele affilate come rasoi. Cose strane si nascondono nelle pozze maleodoranti, in caverne che era meglio rimanessero inesplorate, e il chuul è una di queste. Se ne avvisti uno, il meglio a cui puoi ambire è una mazza pesante per frantumargli il guscio e magari un po' di burro all'aglio. Mmmm. *Istinto*: Fare a fette
-
-- Tagliare qualcosa in due con le possenti chele
-- Ritirarsi in acqua
 
 ## Elfo delle profondità, assassino
 
@@ -107,34 +108,6 @@ Gli spiriti degli alberi e la Signora della Luce Solare sono molto, molto lontan
 - Intessere incantesimi di odio e malizia
 - Radunare gli elfi delle profondità
 - Tramandare conoscenze divine
-
-## Drago
-
-***Solitario, Enorme, Terrificante, Cauto, Accumulatore***
-
-Morso (b\[2d12\]+5 danni, 4 perforanti) 16 PF 5 Armatura
-
-*Lungo, Devastante*
-
-**Qualità Speciali**: Sangue elementale, Ali
-
-Sono le cose più grandi e terribili che questo mondo avrà mai da offrire. *Istinto*: Dominare
-
-- Piegare un elemento alla propria volontà
-- Esigere un tributo
-- Agire con sdegno
-
-## Sventratore grigio
-
-***Solitario, Grande***
-
-Artigli laceranti (d10+3 danni, 3 perforanti) 16 PF 1 Armatura
-
-*Medio, Lungo, Possente*
-
-Già da solo, lo sventratore è una forza di totale distruzione. Enorme e coriaceo, con una fila di denti infrangibili e artigli a complemento, lo sventratore sembra non avere gioia più grande che fare a pezzi le cose. Pietra, carne o acciaio, poco importa. Tuttavia, gli sventratori grigi raramente vanno in giro da soli. Si legano ad altre creature. Alcuni alla nascita, altri quando sono già completamente sviluppati, ma uno sventratore seguirà il padrone a cui si è legato ovunque egli vada, portandogli succulente offerte e proteggendolo mentre dorme. Trovare uno sventratore senza padrone ti farà diventare ricco, se sopravvivi per vendertelo. *Istinto*: Servire
-
-- Fare a pezzi qualcosa
 
 ## Magmin
 
@@ -181,6 +154,21 @@ Tra gli esseri più ambiziosi e territoriali che si conoscano, i naga molto rara
 - Usare antiche magie
 - Proporre un affare o un patto
 
+## Progenie del caos
+
+***Solitario, Amorfo***
+
+Tocco del Caos (d10 danni) 19 PF 1 Armatura
+
+*Medio, Lungo*
+
+**Qualità Speciali**: Forma caotica
+
+Scacciato dalla città, un cultista trova rifugio in borghi e villaggi. Scovato anche lì, fugge verso le colline e incide la sua devozione sulle pareti delle caverne. Trovato di nuovo, viene cacciato con coltelli e torce nelle profondità, strisciando sempre più in basso fino a quando, nei luoghi più profondi, si scopre perduto. Dapprima dimentica il suo nome. Poi dimentica la sua forma. I suoi dei del caos, i più amati, lo benedicono donandogliene una nuova. *Istinto*: Minare l'ordine costituito
+
+- Riscrivere la realtà
+- Liberare il caos dalla sua prigione
+
 ## Salamandra
 
 ***Orda, Grande, Intelligente, Organizzato, Planare***
@@ -195,3 +183,16 @@ Lancia fiammeggiante (b\[2d6\]+3 danni) 7 PF 3 Armatura
 
 - Evocare fuoco elementale
 - Sciogliere (letteralmente) le menzogne
+
+## Sventratore grigio
+
+***Solitario, Grande***
+
+Artigli laceranti (d10+3 danni, 3 perforanti) 16 PF 1 Armatura
+
+*Medio, Lungo, Possente*
+
+Già da solo, lo sventratore è una forza di totale distruzione. Enorme e coriaceo, con una fila di denti infrangibili e artigli a complemento, lo sventratore sembra non avere gioia più grande che fare a pezzi le cose. Pietra, carne o acciaio, poco importa. Tuttavia, gli sventratori grigi raramente vanno in giro da soli. Si legano ad altre creature. Alcuni alla nascita, altri quando sono già completamente sviluppati, ma uno sventratore seguirà il padrone a cui si è legato ovunque egli vada, portandogli succulente offerte e proteggendolo mentre dorme. Trovare uno sventratore senza padrone ti farà diventare ricco, se sopravvivi per vendertelo. *Istinto*: Servire
+
+- Fare a pezzi qualcosa
+

--- a/tecniche-avanzate.md
+++ b/tecniche-avanzate.md
@@ -2,4 +2,295 @@
 title: Tecniche Avanzate
 layout: default
 ---
-Capitolo non tradotto, consultare la [versione inglese](https://book.dwgazetteer.com/advanced_delving.html).
+
+Dungeon World mette in scena uno specifico tipo di avventure fantasy: quelle con elfi e nani, eroi e malvagi, e personaggi che lottano per ricchezze e gloria in un mondo pieno di pericoli. Potresti avere un'idea per qualcosa di diverso; magari il tuo Dungeon World è ambientato su un pianeta desertico devastato, popolato da cannibali selvaggi e governato da arroganti psionici. O forse vuoi giocare una campagna dove gli umani sono l'unica razza disponibile, ma appartengono a clan o famiglie tanto diverse tra loro quanto un gnomo è diverso da un nano. Tutto ciò è possibile (o per meglio dire, è incoraggiato) con un minimo di sforzo. Questo capitolo ti spiegherà come puoi trasformare Dungeon World nel *tuo* Dungeon World.
+
+## Creazione delle Mosse
+
+Il miglior punto di partenza per iniziare il tuo percorso di adattamento di Dungeon World sono le mosse. Molti dei fronti, pericoli e altri elementi del tuo gioco dovranno già prevedere mosse personalizzate, quindi è un punto di partenza semplice e naturale. Potresti voler creare mosse che rappresentino gli effetti di una particolare minaccia ("Quando ti avventuri da solo nelle Sale Maledette..."). Potresti creare mosse che riguardino qualcosa di particolarmente importante per la tua ambientazione ("Quando nuoti nelle acque oscure..."). Man mano che acquisisci più esperienza, potrai creare mosse per espandere una classe o crearne una interamente tua.
+
+### Primi passi
+
+Da dove vengono le mosse? Puoi dare il via a una nuova mossa a partire dall'innesco. Risulterà chiaro che alcune azioni debbano essere una mossa. Questo è il punto di partenza più comune per le mosse. Vedrai tentare alcune azioni che avranno tutta l'aria di non essere contemplate tra le mosse esitenti e di necessitare di regole proprie.
+
+Puoi iniziare con l'effetto. Questo è particolarmente utile per le mosse di classe. Sai che lanciare un incantesimo è qualcosa che fa il mago, quindi cosa innesca quell'effetto?
+
+Più raramente, puoi voler iniziare con la meccanica. A volte penserai a qualcosa di interessante, come un demone addomesticato la cui felicità è una statistica che varia di continuo, e partirai da lì. Sii cauto con qualsiasi idea che sia interamente meccanica. Poiché le mosse iniziano e finiscono sempre con la finzione, un'idea meccanica è la parte meno importante della mossa.
+
+Inoltre, puoi sempre prendere una mossa da un altro gioco. Dungeon World è solo uno dei tanti giochi basati su mosse e potresti essere ispirato da uno degli altri. Di solito non è così difficile modificare una mossa già esistente per usarla in Dungeon World.
+
+### Tipi di mosse
+
+Il ruolo che la mossa svolge determina che tipo di mossa stai creando.
+
+Le mosse per affrontare l'ambiente o le caratteristiche speciali che hai aggiunto a Dungeon World sono mosse speciali. Queste mosse sono solitamente dominio del GM, un modo per far risaltare parti del mondo. Poiché le mosse sono sempre innescate dai giocatori, la maggior parte delle mosse di questo tipo dovrebbero essere scritte o stampate da qualche parte dove tutti possano tenerle d'occhio, a meno che la mossa non copra qualcosa di cui i personaggi dei giocatori non dovrebbero avere idea.
+
+Le mosse che riflettono una competenza o potere speciale, o qualcosa che i giocatori fanno, sono solitamente mosse di classe. Se la mossa è chiaramente legata a una classe specifica, aggiungila a quella classe. Se la mossa è legata a qualche concetto a cui potrebbero accedere più classi, come una mossa disponibile solo a coloro che hanno visto oltre i Neri Cancelli della Morte, puoi creare una classe compendio per quelle mosse. Una classe compendio è come una mini-classe, è una raccolta di mosse attorno a un tema della fiction. Ne parleremo in dettaglio più avanti.
+
+Se la tua mossa è qualcosa che i giocatori fanno ma non è associata a nessun tema o classe specifica, è probabilmente una mossa base o speciale. Se viene tirata in ballo di continuo, è una mossa base, se emerge più raramente, è una mossa speciale.
+
+Le mosse fatte dai giocatori in risposta ai mostri, come gli effetti di una malattia o resistere al violento soffio di vento da un elementale dell'aria, sono mosse dei giocatori associate a quel mostro. Le mosse dei giocatori associate a un mostro sono piuttosto rare, la maggior parte dei modi in cui un giocatore interagirà con un mostro sono coperti dalle mosse base e di classe.
+
+Le mosse fatte dai mostri contro i giocatori non sono mosse dei giocatori. Sono mosse dei mostri, semplici dichiarazioni di ciò che il mostro fa. Cercare di trasformare ogni mossa di un mostro in una mossa dei giocatori ostacolerà seriamente la tua creatività.
+
+### Mosse del Mondo
+
+Il tuo Dungeon World è pieno di cose fantastiche, giusto? È probabile che alcune di queste cose fantastiche meritino o richiedano mosse personalizzate per riflettere esattamente ciò che fanno. Considera questa di Chris Bennet:
+
+---
+
+Quando **apri un tombino di fogna**, tira+FOR: *Con un 10+, scegli 2. *Con un 7&ndash;9 scegli 1.
+
+- Eviti di essere coperto da feci e interiora di animali marci provenienti dalle fogne sopra.
+- Eviti che un cubo gelatinoso ti cada addosso.
+- Trovi un'entrata segreta nel retro dove è tenuta la figlia del mercante.
+
+---
+
+Questa mossa è tosta perché è fortemente legata a un luogo particolare, in un momento particolare. Questa mossa è stata scritta su richiesta per una campagna di Dungeon World di Jason Morningstar nella quale i giocatori entravano in fogne particolarmente orribili per trovare la figlia di un potente mercante. Due delle opzioni qui sono direttamente legate a quella precisa situazione.
+
+Perché dovresti scrivere una mossa come quest invece di usare semplicemente sfidare il pericolo? Non dovresti, di solito. Aprire un tombino di fogna pressurizzato è certamente pericoloso, quindi potresti usare *sfidare il pericolo*. Questa mossa ha però il vantaggio di predisporre le scelte in anticipo. Questa è in realtà una tecnica molto efficace: se c'è una situazione particolare che è probabile che causi *sfidare il pericolo*, puoi scrivere una mossa personalizzata che descriva la scelta difficile da fare per risparmiarti qualche pensiero nel momento.
+
+L'altro punto di forza delle mosse come questa è che mettono in risalto qualcosa di importante. Scegliendo l'innesco "quando apri un tombino di fogna" invece di "quando agisci nonostante una minaccia imminente" la mossa sottolinea che queste fogne sono sempre pericolose.
+
+### Mosse di Classe
+
+Ogni classe ha abbastanza mosse per arrivare fino al decimo livello, ma ciò non significa che non puoi aggiungerne altre. Aggiungere mosse a una classe può dimostrare la tua idea di Dungeon World. Prendi questa, per esempio:
+
+---
+
+Quando **reclami una stanza per la tua divinità**, marchia ogni ingresso e tira +SAG: *Con un 10+, la stanza è vincolata alla pace: nessuno può compiere azioni che causino danni fisici al suo interno. *Con un 7&ndash;9, la stanza è vincolata alla pace, ma la manifestazione del potere divino attira attenzione. Puoi dissolvere il vincolo di pace a tuo piacimento.
+
+---
+
+Questa mossa presenta un lato leggermente diverso di Dungeon World, uno che può richiedere pace (qualcosa che di solito non viene facilmente ai PG). Questo potrebbe non essere adatto a ogni campagna di Dungeon World, ma è un ottimo modo per mostrare come appare il tuo Dungeon World, riflettendolo nei personaggi.
+
+Quando aggiungi una mossa, osserva attentamente a quale classe appartiene. Evita di dare a una classe mosse che invadono le aree di competenza di un'altra classe. Se il ladro può lanciare incantesimi altrettanto bene del mago, il mago si sentirà probabilmente marginalizzato. Questo è il motivo per cui le mosse multiclasse funzionano come se fossero di un livello inferiore, in modo che la nicchia di ogni classe sia in qualche modo protetta.
+
+Stai attento con qualsiasi mossa che fornisce lo stesso beneficio di una mossa esistente anche se ha un diverso innesco. Le mosse che aggiungono danni, in particolare, dovrebbero essere evitate per la maggior parte a meno che non siano create con cura e con inneschi interessanti. Lo stesso vale per le mosse che aggiungono armatura. Le classi attuali hanno aumenti di danni e armatura che riflettono il pericolo complessivo di Dungeon World. Darne di più può annullare il potenziale di alcune minacce.
+
+## Nuove Classi
+
+Una volta che avrai preso dimestichezza con la creazione di nuove mosse e la personalizzazione delle classi in Dungeon World, ti salterà probabilmente all'occhio una cosa. Una classe è semplicemente una raccolta di mosse a tema che lavorano insieme per creare un certo insieme di capacità e qualità, le quali conferiscono alla classe la sua unicità. Se te la senti, creare una nuova classe è il prossimo passo naturale.
+
+La prima cosa che devi considerare è come la classe si relaziona alle classi esistenti. Nessun personaggio esiste in isolamento, quindi devi riflettere attentamente su cosa rende la nuova classe diversa da quelle esistenti.
+
+Un eccellente primo passo per creare una nuova classe è pensare a quali personaggi immaginari vorresti prendere a ispirazione. Non ricalcare pedissequamente ciò che quel personaggio sa fare (dopotutto, non è un personaggio di Dungeon World), ma usalo come guida: cosa rende quel personaggio così interessante?
+
+Le ispirazioni per le classi in questo libro sono abbastanza chiare e rese ancora più evidenti dalle note a margine. Osserva come non tutte le ispirazioni sono prese nella loro interezza: i maghi di Discworld hanno ispirato lo stile leggermente pomposo del mago, ma questi è molto più competente e lancia incantesimi in un modo più simile a come farebbe nella Terra Morente di Vance. Lasciati ispirare per trovare uno stile, non tentare di ricreare ciò che un dato personaggio sa fare in un dato libro.
+
+Quando ti sei fatto un'idea chiara, puoi definire alcuni aspetti fondamentali che non impattano in modo sostanziale sulla scritura di singole mosse: PF, Legami, Aspetto, Equipaggiamento, Allineamento, Razze.
+
+I PF di una classe ammontano a una base + Costituzione. La base dei PF è quasi sempre 4, 6, 8 o 10. Avere più PF del guerriero e del paladino metterà in ombra quei personaggi a meno che non si stia attenti. Avere meno PF del mago è probabilmente una condanna a morte per il personaggio. Una base di 4 PF teremina una classe deliberatamente fragile, che avrà bisogno dell'aiuto degli altri quando le spade vengono sguainate. Una base di 6 PF è per quelle classi che non sono preparate a combattere, ma possono quantomeno incassare un colpo. Una base di 8 PF è sufficiente per incassare alcuni colpi e partecipare un po' al combattimento, mentre 10 PF di base sono per guerrieri esperti e coloro che non temono la battaglia.
+
+Il danno va scelto tra i dadi disponibili: d4, d6, d8, d10. Le classi presentate qui usano tutte un singolo dado senza bonus statico, ma non c'è motivo per non sperimentare con altre opzioni: 2d4 o 1d6+2, per esempio. Un alto numero di PF tende ad andare in coppia con un alto danno, ma la tua nuova classe potrebbe essere un muro per la pace o un cannone di cristallo, fragile ma pericoloso.
+
+Gli allineamenti mostrano l'attitudine iniziale di quella classe. La maggior parte delle classi avrà Neutrale tra le opzioni, poiché solo le classi più devote sono così vincolate a un ideale da anteporlo agli interessi personali. Una buona mossa di allineamento è qualcosa che accade con una certa regolarità e guida il giocatore verso un tipo di azione che altrimenti potrebbe non considerare mai. Un allineamento che accade come parte del normale corso del gioco, come "Quando guadagni un tesoro...", non mostra davvero gli ideali del personaggio. Specificare alcuni requisiti, tipo "Quando guadagni un tesoro attraverso menzogne e inganni...", aggiunge un elemento legato agli ideali. In questo modo l'allineamento dice qualcosa sul personaggio (valorizza il truffare i creduloni) e richiede al giocatore di pensare a come giocarlo. L'allineamento rivela anche qualcosa sul trapporto di quella classe col mondo. Tutti sanno che i paladini dovrebbero essere esempi di bontà e rettitudine, giusto?
+
+È nei legami che la ragion d'essere di una classe emerge davvero. È tramite i legami che tu, il designer, interagirai più chiaramente con il giocatore durante la creazione del personaggio. A meno che la classe non sia particolarmente socievole o asociale, scrivi quattro legami. Se la classe è molto connessa agli altri, aggiungi un legame; se è isolazionista, rimuovine uno. Evita legami che dettano una posizione morale o etica, ma pensa a come la tua classe interagisce con i personaggi alleati: il ladro ruba cose ma aiuta a proteggere il gruppo dalle trappole, il guerriero difende i suoi alleati e uccide mostri che potrebbero far loro del male, il mago custodisce conoscenze segrete e le condivide o le nasconde. Puoi usare le regole per scrivere nuovi legami come punto di partenza, ma evita di includere nomi propri nei legami iniziali.
+
+L'aspetto è lasciato in gran parte alla tua immaginazione. Questo è un ottimo punto per pensare ai personaggi a cui ti stai ispirando. Come appaiono? Come potrebbero apparire diversi? Includere almeno una scelta sull'abbigliamento aiuta a stabilire lo stile senza che il giocatore si debba preoccupare di far acquistare abiti al suo personaggio.
+
+Le scelte di equipaggiamento dovrebbero sempre includere almeno un'opzione per l'arma e una per l'armatura, a meno che la classe non sia del tutto priva di abilità di combattimento. Anche le razioni da dungeon sono praticamente imprescindibili; un personaggio alle prime armi che entra in un'area pericolosa senza cibo, rasenta la stupidità.
+
+### Classi compendio
+
+Una classe compendio è una classe disponibile solo per i personaggi di livello superiore che soddisfano requisiti specifici. Sono chiamate classi compendio perché sono apparse per la prima volta nei Compendi per Dungeon World Basic. Una classe compendio è la scelta ideale per un tema che può essere applicato a più di una classe.
+
+La struttura di base di una classe compendio prevede una mossa iniziale disponibile solo per i personaggi che hanno vissuto una certa esperienza, come questa:
+
+---
+
+Quando entri nella presenza corporea di un dio o del suo avatar, la prossima volta che guadagni un livello puoi scegliere questa mossa invece di una mossa della tua classe:
+
+#### Vincolo divino
+
+Quando scrivi un nuovo legame, invece di usare il nome di un altro personaggio, puoi usare il nome di una divinità con cui hai avuto contatti. Ogni volta che un legame con una divinità si applica alla tua situazione, puoi segnarlo (come se fosse risolto) per invocare il favore della divinità in modo chiaro e decisivo che il GM dovrà narrare. Alla fine della sessione sostituisci il legame risolto con uno nuovo, con una divinità o un personaggio giocante.
+
+---
+
+Nota che la mossa è disponibile solo dopo che il personaggio ha compiuto una specifica azione, e anche allora solo quando guadagna un nuovo livello. Le classi compendio migliori si basano su ciò che il personaggio ha fatto, non su prerequisiti statistici o su qualcosa che accade a prescindere dalle azioni del giocatore. Una classe compendio disponibile per chiunque abbia appena raggiunto il 5° livello non è molto evocativa; una che si applica solo se hai visto i Neri Cancelli della Morte e sei sopravvissuto per raccontarlo è più interessante.
+
+Una classe compendio di solito ha anche due o tre mosse che possono essere scelte solo dopo che la mossa iniziale è stata presa. Funzionano come normali mosse di classe, ma con il requisito che devi aver già scelto la mossa iniziale della classe compendio.
+
+Le classi compendio sono ideali quando hai un'idea che non riesci a sviluppare in una classe completa. Se non riesci a immaginare come appare la classe o quanti PF ha, o se la classe si sovrappone a classi esistenti, è probabilmente meglio renderla una classe compendio.
+
+## Mosse dell'avventura
+
+Le mosse dell'avventura riguardano direttamente l'avventura in corso. Possono far progredire l'azione, cambiare le ricompense o fungere da passaggio tra un'avventura e l'altra.
+
+Se stai gestendo una giocata breve, magari a una convention o una giornata di gioco, potresti voler anticipare parte dell'esperienza all'inizio della sessione. Ecco una mossa che copre "cos'è successo fin qui" così da poter entrare subito in una breve partita in _media res_.
+
+---
+
+**Combattente Valoroso**: Come se i banditi non fossero già abbastanza! Come se tutte le ferite, i lividi e le percosse subite per mano dei tuoi nemici non fossero sufficienti... ora anche questo. Intrappolato sottoterra con i tuoi compagni d'avventura quando tutto ciò che volevi era tornare in città e sperperare il tuo meritato bottino. Niente da fare, guerriero. Affila quella spada! Sicuramente, gli altri avranno bisogno della tua protezione prima di trovarsi al sicuro. Proprio come l'ultima volta. Di nuovo sulla breccia, giusto? Sicuro come l'oro, a questo punto più d'uno deituoi compari ti dovrà più di un favore...
+
+Dai un'occhiata in giro e tira+CAR. *Con un 10+, scegli due membri del gruppo. *Con un 7&ndash;9, scegline solo uno. *Con un 6-, sei circondato da ingrati.
+
+In un momento di bisogno, puoi riscuotere un favore da un membro del gruppo a tua scelta. Questi deve cambiare la sua azione in una a tua scelta, una volta. Non puoi dare loro un'azione che comporterebbe subire danni direttamente, rinunciare a un oggetto magico che possiedono già o subire un danno immediato. Usalo affinchè siano d'accordo con te, o per darti quella razione extra che desideri, o per cederti il loro posto nella spartizione del bottino. Con le buone si ottiene tutto.
+
+---
+
+La parte più importante di questa mossa non è il tiro o l'effetto, ma ciò che racconta e il suo tono. Prepara il terreno per un'avventura veloce e dà ai giocatori che la leggono un punto di partenza su cui lavorare. Il tiro e il risultato qui sono interessanti, ma non cambiano sostanzialmente il flusso del gioco. Distribuire un set di queste, una per ogni giocatore, insieme a un playbook, è un ottimo modo per gestire una partita a una convention.
+
+Puoi anche adattare la mossa di Fine Sessione per riflettere l'avventura che stai gestendo. Quando lo fai, è fondamentale che spieghi fin da subito ai giocatori la nuova mossa di Fine Sessione. L'obiettivo non è tenerli all'oscuro su cosa fa guadagnare PE, ma far sì che i premi in PE siano legati direttamente all'avventura che stanno per giocare.
+
+---
+
+Quando **finisci la sessione**, invece di usare le domande normali di fine sessione, poni queste:
+
+- Abbiamo imparato qualcosa sul Culto del Dio Squamoso?
+- Abbiamo salvato un villaggio occupato o aiutato a difendere il villaggio di Secor?
+- Abbiamo sconfitto un agente importante del Culto del Dio Squamoso?
+
+---
+
+## Struttura delle mosse
+
+Le mosse seguono sempre una struttura simile. Le parti più basilari di una mossa sono l'innesco ("Quando...") e l'effetto ("allora..."). Tutte le mosse rispondono a questo formato.
+
+### Inneschi
+
+Gli inneschi sono spesso azioni intraprese nella fiction dai personaggi giocanti, ma possono anche far parte della creazione del personaggio o innescarsi all'inizio o alla fine di una sessione. Nota che un innesco non riguarda mai unità di tempo precise. Non scrivere una mossa che inizia con "Quando inizi un round adiacente a un drago." Non ci sono round (e "adiacente" non è forse la locuzione migliore, poiché sembra troppo asettica per descrivere lo *stare vicino a un dannato drago sputafuoco*). Ci sono buone ragioni per cui Preparare Incantesimi non si innesca "Quando passi un'ora a studiare il tuo libro degli incantesimi". Il tempo in Dungeon World è un concetto fluido, come in un film in cui il ritmo dipende dalle circostanze. Non fare affidamento su unità concrete né attorno al tavolo (round) né nella fiction (secondi, minuti, giorni).
+
+Ecco alcuni tipi generici di inneschi:
+
+-   **Quando un personaggio compie un'azione**. Esempi: Discernere Realtà, Arte Arcana (Bardo), Comandare (Ramingo).
+-   **Quando un personaggio compie un'azione in circostanze specifiche**. Esempi: Taglia e Spacca, Vedere Rosso (Guerriero), Colpo alle Spalle (Ladro).
+-   **Quando le circostanze lo richiedono, senza azione del personaggio**. Esempi: Comandare Gregari, Fine della Sessione.
+-   **Quando un personaggio usa un oggetto**. Esempi: Oggetti magici, Eredità (Guerriero).
+-   **Da ora in poi**. Esempi: Serenità (Chierico), Avvelenatore (Ladro).
+
+### Effetto
+
+Gli effetti delle mosse possono essere qualsiasi cosa tu riesca a immaginare; sono tanto vari quanto le tue idee. Non sentirti limitato a tiri di dado, bonus di +1 o scambi di statistiche. Poiché tutte le mosse derivano dalla fiction, un effetto narrativo come "ti trattano come un amico" è tanto potente e utile quanto un +1 al prossimo tiro, se non di più.
+
+Ecco alcuni tipi generici di effetti, una singola mossa può provocarne più di uno:
+
+-   **Tiro di dado**. Esempi: Sfidare il pericolo, Lanciare incantesimi (Mago), Colpo mirato (Ramingo).
+-   **Sostituire statistiche**. Esempi: Nano (Guerriero).
+-   **Negare danni**. Esempi: Il miglior amico dell'uomo (Ramingo).
+-   **Dare un bonus o una penalità, al prossimo tiro o continuato**. Esempi: Non sottovalutarmi (Ladro), Castigo (Paladino).
+-   **Infliggere o curare danni**. Esempi: Raffica, Attacco furtivo (Ladro), Arte arcana (Bardo).
+-   **Scegliere opzioni**. Esempi: Declamare conoscenze, Discernere realtà, Rituale (Mago).
+-   **Mantenere e spendere**. Esempi: Dominare (incantesimo del Mago), Esperto di trappole (Ladro).
+-   **Chiedere e rispondere**. Esempi: Affascinante e onesto (Bardo), Declamare conoscenze.
+-   **Modificare circostanze**. Esempi: Reputazione (Bardo).
+-   **Guadagnare esperienza**. Esempi: Fine sessione.
+-   **Ottenere più informazioni**. Esempi: Parlamentare, Rituale (Mago).
+-   **Aggiungere opzioni**. Esempi: Colpo mirato (Ramingo).
+
+---
+
+## Modificare le basi
+
+Le mosse possono anche cambiare la struttura alla base del gioco. Considera questa mossa, che evita l'uso dei dadi per i danni:
+
+---
+
+Quando **infliggi danni**, invece di tirare i dadi, sostituisci ogni dado con il numero indicato. d4 diventa 2, d6 diventa 3, d8 diventa 4, d10 diventa 5, d12 diventa 6.
+
+Mosse come questa cambiano una delle caratteristiche fondamentali del gioco. Sii molto cauto con le mosse che modificano gli elementi essenziali. Le mosse non dovrebbero mai contraddire i principi o l'agenda del GM, né rompere la regola di base "compi l'azione per ottenere l'effetto".
+
+Ci sono alcune parti del gioco che sono particolarmente agevoli da cambiare. La quantità di PE necessari per salire di livello riflette la nostra visione, ma puoi facilmente rendere l'avanzamento più sporadico o più frequente. Inoltre, le cose per cui i giocatori sono generalmente premiati con PE possono essere facilmente cambiati: se il tuo gioco non riguarda l'esplorazione, il combattimento con i mostri e la ricerca di tesori, modifica la mossa di Fine sessione affinché rifletta questa differenza. Assicurati di condividerla con i tuoi giocatori prima di iniziare la partita.
+
+Un'altra domanda frequente è come rendere, ad esempio, il combattimento con un drago più difficile. La risposta più appropriata è che combattere un drago è più difficile perché narrativamente, il drago è più forte. Banalmente, pugnalare un drago con una lama qualunque non è *taglia e spacca* perché una lama qualunque non può ferirlo. Se tuttavia ciò non fosse sufficiente, considera questa mossa di Vincent Baker, originariamente da Apocalypse World (leggermente modificata per adattarsi alle regole di Dungeon World):
+
+---
+
+Quando **un giocatore compie una mossa che il GM giudica particolarmente difficile**, il giocatore subisce -1 al tiro. Quando il personaggio di un giocatore compie una mossa che il GM giudica chiaramente al di là delle sue capacità, il giocatore subisce -2 al tiro.
+
+---
+
+Il problema con questa mossa è che non si basa su qualcosa di concreto. Piuttosto, è un invito per il GM a fare valutazioni senza un chiaro quadro di riferimento. Se ti trovi a scrivere un mossa personalizzata come questa, considera quale difficoltà stai realmente cercando di catturare e crea una mossa personalizzata per quella situazione specifica. Detto ciò, questa è una mossa personalizzata valida, se ritieni che ti torni utile.
+
+## Sviluppo di una Mossa
+
+Esaminiamo come una mossa si è sviluppata nel tempo. *Taglia e spacca* è stata una delle prime mosse di Dungeon World, originariamente scritta da Tony Dowler. La prima versione era così (questa versione è stata riformattata e modificata solo per la grammatica):
+
+---
+
+Quando **ti butti in combattimento, attaccando i tuoi nemici**, infliggi danni al nemico che stai attaccando, subisci i danni di quel nemico tira +FOR. *Con un 10+, scegli 2. *Con un 7&ndash;9 scegli 1.
+
+-   Previeni che un alleato subisca danni in questo round
+-   Uccidi un nemico di livello inferiore al tuo o, in alernativa, infliggi danni massimi
+-   Posiziona un nemico esattamente dove vuoi che sia (allontanandolo, impedendogli di fuggire, ecc.)
+-   Distribuisci i tuoi danni su un qualsiasi numero di bersagli che puoi raggiungere con la tua arma
+
+---
+
+Il primo problema con questa mossa è che una delle opzioni, prevenire i danni, è molto meno utile delle altre. Poter uccidere direttamente un nemico è quasi sempre meglio che prevenire i danni di quel nemico. La prima grande revisione è stata quella di eliminare questa opzione:
+
+---
+
+Quando **ti butti in combattimento, attaccando i tuoi nemici**, infliggi danni al nemico che stai attaccando, subisci i danni di quel nemico tira +FOR. *Con un 10+, scegli 2. *Con un 7&ndash;9 scegli 1.
+
+-   Uccidi un nemico di livello inferiore al tuo o, in alernativa, infliggi danni massimi
+-   Posiziona un nemico esattamente dove vuoi che sia (allontanandolo, impedendogli di fuggire, ecc.)
+-   Distribuisci i tuoi danni su un qualsiasi numero di bersagli che puoi raggiungere con la tua arma
+
+---
+
+Così rimanevano solo tre opzioni, che è un ottimo numero da presentare quando un 10+ ti permette di sceglierne due. Il giocatore che compiva la mossa doveva sempre rinunciare a una delle opzioni. Tutte le opzioni sono chiaramente utili. Ma c'è ancora un problema, probabilmente il più grave di questa mossa: l'azione nella fiction non è strettamente collegata al risultato.
+
+Considera questa situazione: Gregor attacca un signore delle aquile con la sua possente ascia. Descrive la sua azione così: "Sferro un colpo con l'ascia proprio sulla sua ala, con un ampio fendente." Poi tira la mossa, ottiene un 10 e fa le sue scelte. Infliggere danni massimi è una scelta chiara e deriva direttamente dalla fiction. Le altre opzioni, tuttavia, non hanno molto senso. Se sceglie di dividere i suoi danni, cosa può questo effetto derivare dal suo singolo attacco nella fiction? Come ha fatto quel singolo colpo a colpire anche il treant che aveva alle spalle?
+
+Ridurre l'effetto della mossa affinchè rispettasse la fiction ha portato a questa versione:
+
+---
+
+Quando **attacchi un nemico che può difendersi**, tira+FOR. *Con un 10+, infliggi i tuoi danni ma il tuo nemico non riesce a infliggere i suoi a te. A tua scelta, puoi decidere di subire i danni del nemico e infliggere il doppio dei danni al nemico. *Con un 7&ndash;9, subisci i danni del nemico e infliggi i tuoi danni.
+
+---
+
+A questo punto la mossa aveva solo effetti che potevano chiaramente derivare da un singolo attacco. Qualsiasi azione che non poteva ragionevolmente portare a un contrattacco non era *taglia e spacca*, quindi l'innesco e gli effetti erano coerenti. Purtroppo, il doppio danno era un po' esagerato, quindi lo abbiamo cambiato così:
+
+---
+
+Quando **attacchi un nemico in mischia**, tira+FOR. *Con un 7&ndash;9, infliggi i tuoi danni al nemico e subisci i suoi danni. *Con un 10+ infliggi i tuoi danni al nemico. A tua scelta, puoi decidere di subire anche i danni del nemico per infliggere +2 danni.
+
+---
+
++2 danni è un chiaro vantaggio, ma non esagerato. L'unico problema qui è che ha ridotto gli effetti di un attacco a subire danni. I mostri fanno molto di più che semplicemente toglierti PF; i mostri ti scagliano per la stanza e distruggono il terreno sotto ai tuoi piedi, perché non possono fare lo stesso in risposta?
+
+---
+
+Quando **attacchi un nemico in mischia**, tira+FOR. ✴Con un 10+, infliggi i tuoi danni al nemico ed eviti il suo attacco. A tua scelta, puoi decidere di infliggere +1d6 danni ed esporti all'attacco del nemico. ✴Con un 7&ndash;9, infliggi i tuoi danni al nemico, ma il nemico effettua un attacco contro di te. 
+
+---
+
+Questa versione (quella finale) permette a un mostro di "attaccare" non solo infliggere danni. Questo apre a una serie di mosse interessanti per i mostri. +1d6 danni invece di +2 rende questa opzione più eccitante (e leggermente più potente). La riformulazione aggiunge chiarezza.
+
+## Il GM
+
+Modificare le regole dal lato del GM è tutta un'altra cosa rispetto alla scrittura di mosse personalizzate per i giocatori. Scrivere mosse per il GM è la parte facile. Poiché una mossa del GM è solo una dichiarazione di qualcosa che accade nella fiction, sentiti libero di scriverne di nuove come preferisci. La maggior parte delle volte scoprirai che sono solo casi specifici di una delle mosse già stabilite, ma occasionalmente te ne uscirai con qualcosa di nuovo. Tieni solo a mente lo spettro delle mosse da dure a morbide, i tuoi principi e la tua agenda, e non potrai sbagliare.
+
+Modificare l'agenda o i principi del GM è uno dei cambiamenti più grandi che puoi apportare al gioco. Cambiare queste aree richiederà probabilmente modifiche in tutto il resto del gioco, oltre ad attività di playtest per consolidare il risultato.
+
+**Gioca per scoprire cosa accadrà** è la parte meno modificabile dell'agenda del GM. Altre opzioni, come "gioca seguendo la tua trama prefissata" o "gioca per mettere alla prova le abilità dei giocatori" entreranno in forte contrasto con le altre regole. Le mosse danno ai giocatori abilità che possono cambiare rapidamente il corso di un'avventura pianificata; se non giochi per scoprire cosa succede, dovrai opporti alle mosse dei giocatori ad ogni passaggio o riscrivere molti passaggi.
+
+**Riempi di avventura le vite dei personaggi** potrebbe essere riformulato, ma è difficile cambiarlo davvero. "Riempi di intrighi le vite dei personaggi" potrebbe funzionare, ma l'intrigo sembra solo un tipo di avventura. Rimuovere completamente questa agenda richiederà una rielaborazione importante poiché la struttura delle mosse si basa su di essa. Gli effetti di un fallimento e le mosse morbide del GM sono tutti lì per creare una vita di avventure.
+
+**Dipingi un mondo fantastico** è forse la parte più facile da cambiare, ma richiede comunque una considerevole riscrittura delle mosse di classe. Un mondo storico, un mondo cupo o un mondo utopico sono tutti possibili, ma dovrai ripensare attentamente molte mosse. Un mondo storico richiederà che magia, equipaggiamento e diverse altre sezioni siano quasi interamente riscritte o rimosse. Un mondo cupo può sopravvivere solo se le mosse dei giocatori avessero prezzi più oscuri. Un mondo utopico non avrà bisogno di molte delle mosse come sono scritte. Tuttavia, questa è la parte più facile dell'agenda da cambiare, poiché richiede di cambiare le mosse, non la strutture alla base del gioco.
+
+I principi del GM sono più modificabili dell'agenda, ma possono comunque cambiare seriamente il gioco con solo piccole modifiche. **Rivolgiti ai personaggi, non ai giocatori; Fai una mossa che abbia senso; Non pronunciare mai il nome della tua mossa; Inizia e finisci con la fiction;** e **Sii un fan dei personaggi** sono i principi più importanti. Senza di questi, la conversazione di gioco e l'uso delle mosse rischiano di rompersi.
+
+**Fai tuo ciò che è fantastico; Rendi vivo ogni mostro; Dai un nome a ogni persona** e **Pensa pericoloso;**sono fondamentali per lo spirito di Dungeon World e per l'esplorazione tipica del fantasy. Questi sono modificabili, ma cambiano l'ambientazione del gioco. Se decidi di cambiarne uno, potresti doverli cambiare tutti.
+
+**Pensa ai retroscena** e **Fai domande e usa le risposte** sono importanti per gestire bene Dungeon World. Si applicano anche a molti altri giochi nello stesso stile. Il gioco risentirà della loro rimozione, ma la conversazione del gioco potrà continuare. Questi sono anche alcuni dei principi più portabili, applicabili a molti altri giochi. Possono persino funzionare in giochi con stili molto differenti.
+
+Un principio addizionale che alcune persone preferiscono aggiungere è **Metti alla prova i loro legami**. Questo principio è interamente compatibile con gli altri e con tutte le mosse, ma cambia un po' il focus del gioco. I fronti devono essere ripensati per funzionare bene con questa aggiunta, e potresti dover implementare mosse che lo mettano in risalto.
+
+## Mostri
+
+Lo strumento migliore per modificare i mostri si trova nelle domande usate per crearli. Le modifiche più semplici sono quelle che regolano la letalità o la casualità e tuo piacimento.
+
+Una modifica più interessante riguarda le domande che vengono chieste per presentare uno scorcio differente di quel mostro. I punti di vista sottintesi nelle domande implicano che un mostro sia più o meno simile ad altre creature: potrebbero essere di diversi allineamenti e non sempre avversi ai personaggi giocanti. Se vuoi che Dungeon World sia centrato sul dare la caccia e annientare mostri cattivi, puoi riscrivere alcune delle domande, magari aggiungento questa:
+
+### Il mostro è davvero, davvero cattivo. Scegli una che ne spieghi il perché:
+
+- È un'intrusione dei Grandi Antichi Dietro alle Mura: Planare, +5 danno
+- È il prodotto degli Antichi Maghi della Torre Rossa: Costrutto, +5 PF
+- Risale al Tempo Prima del Uomini: Primordiale, +5 danno, +5 PF
+
+Quando inventi nuove domande per i mostri, puoi voler reinterpretare mostri esistenti rispondendo di nuovo a tutte le loro domande, oppure usare le nuove domande solo per mostri nuovi. Se le nuove domande che aggiungi o cambi sono domande chiave per la tua visione di Dungeon World, la cosa migliore è rivedere tutti i mostri che usi alla luce di esse; se le domande si applicano solo a uno specifico tipo di mostro invece, usale solo per creare nuovi mostri.


### PR DESCRIPTION
@claudiofreda con questa PC completo il lavoro di traduzione delle parti mancanti.

Ho tradotto il testo che era linkato dal materiale originale ([qui](https://book.dwgazetteer.com/advanced_delving.html)) che ad una veloce analisi mi sembra essere progredito rispetto ad una prima edizione di DW.
Ho dovuto eliminare la citazione ad un principio del DM che non compare nel relativo capitolo su dungeonworld.it, né nella traduzione Narrattiva.

Come sempre ho cercato di non stravolgere il senso dell'esposizione, attendomi a quanto riportato dagli autori, ma cercando di usare un Italiano idiomatico per quanto possibile. Non sono un professionista, quindi ho cercato di fare del mio meglio.

La formattazione dovrebbe essere coerente col resto del testo, così come la nomenclatura specifica (mosse, principi, classi, etc).

Per sveltire la review, se trovi qualcosa che vuoi che io cambi, puoi usare la modalità suggerimento nei commenti.

Ultima informazione: ho aggiornato navigazione e home page usando il buon senso, per rimuovere i riferimenti a una traduzione parziale. Spero di non aver fatto niente di poco calzante, ovviamente nel caso fammi sapere.

A disposizione