### PR TITLE
Rimossa label per mancata traduzione da sezione tradotta.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -65,7 +65,7 @@
               <li><a href="/prima-sessione">Prima Sessione</a></li>
               <li><a href="/fronti">Fronti</a></li>
               <li><a href="/il-mondo">Il Mondo</li>
-                <li><a href="/tecniche-avanzate">Tecniche Avanzate <span class="label label-default">inglese</span></a></li>
+                <li><a href="/tecniche-avanzate">Tecniche Avanzate</a></li>
             </ul>
           </li>
           <li class="dropdown">


### PR DESCRIPTION
Ho rimosso una label `Inglese` che era rimasta nel menu sulla voce delle tecniche avanzate.